### PR TITLE
Fix correlation-parser's spinning

### DIFF
--- a/correlation-parser/Cargo.toml
+++ b/correlation-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "correlation-parser"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Tibor Benke <ihrwein@gmail.com>"]
 build = "build.rs"
 

--- a/correlation-parser/src/lib.rs
+++ b/correlation-parser/src/lib.rs
@@ -54,10 +54,6 @@ impl<P, E, T, TF, TM> CorrelationParserBuilder<P, E, T, TF, TM> where P: Pipe, E
             },
             Err(err) => {
                 let errmsg = format!("Failed to initialize correlation-parser from configuration file: {}", &err);
-                while let Some(err) = err.cause() {
-                    info!("Error: {}", err.description());
-                    info!("Cause: {}", &err);
-                }
                 Err(OptionError::verbatim_error(errmsg))
             }
         }

--- a/correlation-parser/src/lib.rs
+++ b/correlation-parser/src/lib.rs
@@ -10,7 +10,6 @@ use correlation::correlator::{Correlator, CorrelatorFactory};
 use std::borrow::Borrow;
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex, MutexGuard};
-use std::error::Error;
 use std::time::Duration;
 use std::str::FromStr;
 use syslog_ng_common::{MessageFormatter, LogMessage};

--- a/correlation-parser/tests/parse.rs
+++ b/correlation-parser/tests/parse.rs
@@ -52,7 +52,7 @@ fn test_syslog_ng_does_not_spin_with_invalid_yaml_configuration() {
         unsafe { syslog_ng_global_init(); }
     });
 
-    let config_file = "tests/spinning.json";
+    let config_file = "tests/spinning.yml";
 
     let cfg = GlobalConfig::new(0x0308);
     let mut builder = CorrelationParserBuilder::<MockPipe, MockEvent, MockLogTemplate, MockLogTemplateFactory, MockTimer<MockEvent, MockLogTemplate>>::new(cfg);


### PR DESCRIPTION
This PR fixes the spinning behavior of correlation-parser.

It was caused by an infinite loop, which I removed (the error is still reported).

I also fixed the bad test which should have reproduced this issue.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ihrwein/syslog-ng-rust-modules/37)

<!-- Reviewable:end -->
