### PR TITLE
actiondb: Fix the pattern insertion of SuffixTable

### DIFF
--- a/actiondb-parser/actiondb/src/matcher/suffix_array/impls.rs
+++ b/actiondb-parser/actiondb/src/matcher/suffix_array/impls.rs
@@ -187,13 +187,13 @@ impl ParserEntry for ParserE {
         self.parser.parse(value).and_then(|kvpair| {
             let value = value.ltrunc(kvpair.value().len());
 
-            if let Some(child) = self.child() {
+            if value.is_empty() {
+                self.create_match_result(kvpair)
+            } else if let Some(child) = self.child() {
                 child.parse(value).and_then(|mut result| {
                     result.insert(kvpair);
                     Some(result)
                 })
-            } else if value.is_empty() {
-                self.create_match_result(kvpair)
             } else {
                 None
             }

--- a/actiondb-parser/actiondb/src/matcher/suffix_array/interface.rs
+++ b/actiondb-parser/actiondb/src/matcher/suffix_array/interface.rs
@@ -17,9 +17,13 @@ pub trait Entry {
     fn insert(&mut self, pattern: Pattern) {
         if pattern.pattern().is_empty() {
             self.set_pattern(Some(pattern));
-        } else {
-            let sa = Self::SA::new();
-            self.set_child(Some(sa));
+        }
+        else {
+            if self.child().is_none() {
+                let sa = Self::SA::new();
+                self.set_child(Some(sa));
+            }
+
             self.child_mut().expect("Failed to get a child").insert(pattern);
         }
     }

--- a/actiondb-parser/actiondb/src/matcher/suffix_array/test.rs
+++ b/actiondb-parser/actiondb/src/matcher/suffix_array/test.rs
@@ -47,6 +47,21 @@ fn create_populated_suffix_table() -> SuffixTable {
     root
 }
 
+fn assert_suffix_table_parse<'a, 'b>(patterns: &[&'a str], values: &[&'b str]) {
+    let mut root = SuffixTable::new();
+
+    for pattern in patterns {
+        let compiled_pattern = ::grammar::parser::pattern(pattern).expect("Failed to compile pattern");
+        let mut pattern = Pattern::with_random_uuid();
+        pattern.set_pattern(compiled_pattern);
+        root.insert(pattern);
+    }
+
+    for value in values {
+        assert_eq!(true, root.parse(value).is_some());
+    }
+}
+
 #[test]
 fn test_given_parser_trie_when_a_parser_is_not_matched_then_the_parser_stack_is_unwind_so_an_untried_parser_is_tried() {
     let root = create_populated_suffix_table();
@@ -149,17 +164,12 @@ fn test_given_suffix_array_when_literals_are_inserted_then_it_can_find_the_strin
 
 #[test]
 fn test_given_parser_when_it_receives_utf_8_strings_then_it_does_not_panic() {
-    let pattern = "%{GREEDY}¡%{GREEDY}";
-    let compiled_pattern = ::grammar::parser::pattern(pattern)
-                  .expect("Failed to compile pattern when it includes UTF-8 multibyte characters");
 
-    let mut pattern = Pattern::with_random_uuid();
-    pattern.set_pattern(compiled_pattern);
 
-    let mut root = SuffixTable::new();
-    root.insert(pattern);
+    let patterns = ["%{GREEDY}¡%{GREEDY}"];
+    let values = ["micek ¡micek"];
 
-    assert_eq!(true, root.parse("micek ¡micek").is_some());
+    assert_suffix_table_parse(&patterns, &values);
 }
 
 #[test]

--- a/actiondb-parser/actiondb/src/matcher/suffix_array/test.rs
+++ b/actiondb-parser/actiondb/src/matcher/suffix_array/test.rs
@@ -163,9 +163,23 @@ fn test_given_suffix_array_when_literals_are_inserted_then_it_can_find_the_strin
 }
 
 #[test]
+fn test_given_suffix_array_when_multiple_patterns_are_inserted_with_the_same_prefix_then_it_can_match_all_of_them() {
+    let patterns = [
+        "test: %{INT:a}",
+        "test: %{INT:a} test"
+    ];
+
+    let values = [
+        "test: 1 test",
+        "test: 1",
+        "test: 23"
+    ];
+
+    assert_suffix_table_parse(&patterns, &values);
+}
+
+#[test]
 fn test_given_parser_when_it_receives_utf_8_strings_then_it_does_not_panic() {
-
-
     let patterns = ["%{GREEDY}¡%{GREEDY}"];
     let values = ["micek ¡micek"];
 


### PR DESCRIPTION
When inserting multiple patterns with the same prefix, the previous `SuffixTable` is overwritten by the `Entry::insert()` method.

This PR fixes this issue by checking the existence of the child node.

Example config:

``` yaml
patterns:
  -
    uuid: "3d2cba0c-e241-464a-89c3-8035cac8f73e"
    name: "TEST"
    pattern: "test: %{INT:.a}"
  -
    uuid: "4d2cba0c-e241-464a-89c3-8035cac8f73f"
    name: "TEST2"
    pattern: "test: %{INT:.a} test"
```

In this case, the first pattern would overwrite the second pattern's `%{INT:.a}` node (`SuffixTable` instance).
