### PR TITLE
syslog-ng-rs: fix possible data race in MessageFormatter

### DIFF
--- a/actiondb-parser/src/msgfilller.rs
+++ b/actiondb-parser/src/msgfilller.rs
@@ -34,7 +34,7 @@ impl MessageFiller {
                           result: &MatchResult) {
         for (key, value) in result.values() {
             let (key, value) = formatter.format(key, value);
-            msg.insert(key, value.as_bytes());
+            msg.insert(key.as_str(), value.as_bytes());
         }
     }
 
@@ -44,7 +44,7 @@ impl MessageFiller {
         if let Some(values) = result.pattern().values() {
             for (key, value) in values {
                 let (key, value) = formatter.format(key, value);
-                msg.insert(key, value.as_bytes());
+                msg.insert(key.as_str(), value.as_bytes());
             }
         }
     }
@@ -52,14 +52,14 @@ impl MessageFiller {
     fn fill_name(formatter: &mut MessageFormatter, msg: &mut LogMessage, result: &MatchResult) {
         if let Some(name) = result.pattern().name() {
             let (key, value) = formatter.format(keys::PATTERN_NAME, name);
-            msg.insert(key, value.as_bytes());
+            msg.insert(key.as_str(), value.as_bytes());
         }
     }
 
     fn fill_uuid(formatter: &mut MessageFormatter, msg: &mut LogMessage, result: &MatchResult) {
         let uuid = result.pattern().uuid().hyphenated().to_string();
         let (key, value) = formatter.format(keys::PATTERN_UUID, &uuid);
-        msg.insert(key, value.as_bytes());
+        msg.insert(key.as_str(), value.as_bytes());
     }
 
     fn fill_tags(msg: &mut LogMessage, result: &MatchResult) {

--- a/syslog-ng-rs/syslog-ng-common/src/formatter.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/formatter.rs
@@ -11,14 +11,12 @@ use std::fmt::Write;
 /// Applies transformations to key-value pairs.
 #[derive(Clone)]
 pub struct MessageFormatter {
-    buffer: String,
     prefix: Option<String>,
 }
 impl MessageFormatter {
     /// Creates a new MessageFormatter without any transformations.
     pub fn new() -> MessageFormatter {
         MessageFormatter {
-            buffer: String::new(),
             prefix: None,
         }
     }
@@ -28,20 +26,20 @@ impl MessageFormatter {
     }
 
     /// Formats the given `key` and/or `value` parameters and returns the formatted pair as a tuple.
-    pub fn format<'a, 'b, 'c>(&'a mut self, key: &'b str, value: &'c str) -> (&'a str, &'c str) {
-        self.buffer.clear();
-        self.apply_prefix(key);
-        (&self.buffer, value)
+    pub fn format<'a, 'b, 'c>(&'a mut self, key: &'b str, value: &'c str) -> (String, &'c str) {
+        let mut buffer = String::new();
+        self.apply_prefix(key, &mut buffer);
+        (buffer, value)
     }
 
-    fn apply_prefix(&mut self, key: &str) {
+    fn apply_prefix(&mut self, key: &str, buffer: &mut String) {
         match self.prefix.as_ref() {
             Some(prefix) => {
-                let _ = self.buffer.write_str(prefix);
-                let _ = self.buffer.write_str(key);
+                let _ = buffer.write_str(prefix);
+                let _ = buffer.write_str(key);
             }
             None => {
-                let _ = self.buffer.write_str(key);
+                let _ = buffer.write_str(key);
             }
         };
     }


### PR DESCRIPTION
`MessageFormatter::format` can be called from different threads (from C side), so the key buffer should be local.

---

Reproduction with syslog-ng:

```
options {
    threaded(yes);
};

log {
    source { syslog(port(55555)); };
    parser { actiondb(pattern-file("actioncrash.yml")); };
    destination { file("/dev/stdout"); };
};
```

```
patterns:
  - uuid: "6d2cba0c-e241-464a-89c3-8035cac8f732"
    name: "TEST"
    pattern: "%{GREEDY:test_string} %{GREEDY:test_string2} %{GREEDY:test_string3}"
```

```
$ bin/loggen -P --active-connections=10 127.0.0.1 55555
```
