### PR TITLE
Update glib and fix warnings

### DIFF
--- a/syslog-ng-rs/syslog-ng-common/Cargo.toml
+++ b/syslog-ng-rs/syslog-ng-common/Cargo.toml
@@ -11,8 +11,8 @@ license = "MIT/Apache-2.0"
 [dependencies]
 log = "0.3"
 syslog-ng-sys = { path = "../syslog-ng-sys" }
-glib = "0.0.8"
-glib-sys = "0.3.0"
+glib = "0.1.1"
+glib-sys = "0.3.2"
 libc = "0.2.13"
 quick-error = "1.1.0"
 time = "0.1.35"

--- a/syslog-ng-rs/syslog-ng-common/src/messages.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/messages.rs
@@ -48,9 +48,11 @@ impl InternalMessageSender {
 
     /// Returns a `LogLevelFilter` based on syslog-ng's current log level.
     pub fn level() -> LogLevelFilter {
-        if messages::trace_flag != 0 {
+        let trace_flag = unsafe { messages::trace_flag };
+        let debug_flag = unsafe { messages::debug_flag };
+        if trace_flag != 0 {
             LogLevelFilter::Trace
-        } else if messages::debug_flag != 0 {
+        } else if debug_flag != 0 {
             LogLevelFilter::Debug
         } else {
             LogLevelFilter::Info


### PR DESCRIPTION
I was asked to do glib crate upgrade here: https://github.com/rust-lang/rust/pull/34198#issuecomment-270708912 (not the glib lib, just its bindings!)

We have two options:
* yank it immediately (but it's not a 100% solution)
* upgrade the glib crate

As far as I remember the released syslog-ng-common crate is pretty outdated, the "always use the latest version" approach was used. I checked on crates.io and I can still release a new version of it, so I'd do the following things:
1. release syslog-ng-common after this PR is reviewed and merged
2. yank it

And before I forget, I wish you happy new year! :champagne: :smile: 
