### PR TITLE
syslog-ng-common: bump version to 0.9.1

### DIFF
--- a/syslog-ng-rs/syslog-ng-common/Cargo.toml
+++ b/syslog-ng-rs/syslog-ng-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-ng-common"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Tibor Benke <ihrwein@gmail.com>"]
 homepage = "https://github.com/ihrwein/syslog-ng-rs"
 repository = "https://github.com/ihrwein/syslog-ng-rs"


### PR DESCRIPTION
Signed-off-by: Tibor Benke <ihrwein@gmail.com>